### PR TITLE
Fixed bug where wrong config would be deleted

### DIFF
--- a/app/src/main/java/com/jscj/qrcodescanner/settings/SettingsUI.kt
+++ b/app/src/main/java/com/jscj/qrcodescanner/settings/SettingsUI.kt
@@ -254,6 +254,7 @@ class SettingsUI(private val settingsViewModel: SettingsViewModel) {
     fun ShowConfigurationsDialog(configurations: Map<String, Config>, onDismiss: () -> Unit) {
         val configurationEntries = configurations.entries.toList()
         val showDeleteConfirmationDialog = remember { mutableStateOf(false) }
+        val selectedConfiguration = remember { mutableStateOf("") }
 
         AlertDialog(
             onDismissRequest = { onDismiss() },
@@ -272,6 +273,7 @@ class SettingsUI(private val settingsViewModel: SettingsViewModel) {
                                 },
                                 onDelete = {
                                     showDeleteConfirmationDialog.value = true
+                                    selectedConfiguration.value = entry.key
                                 }
                             )
                         }
@@ -290,9 +292,9 @@ class SettingsUI(private val settingsViewModel: SettingsViewModel) {
 
         if (showDeleteConfirmationDialog.value) {
             ShowDeleteConfirmationDialog(
-                configurationName = configurationEntries[0].key,
+                configurationName = selectedConfiguration.value,
                 onConfirm = {
-                    settingsViewModel.deleteConfiguration(configurationEntries[0].key)
+                    settingsViewModel.deleteConfiguration(selectedConfiguration.value)
                     showDeleteConfirmationDialog.value = false
                 }
             )


### PR DESCRIPTION
There was a bug where when you tried to delete a specific config, it would always delete the 0th config in the list. That issue has now been fixed.